### PR TITLE
Enables the addition of team access

### DIFF
--- a/examples/test_app/main.tf
+++ b/examples/test_app/main.tf
@@ -6,6 +6,7 @@ variable "parent_zone" {}
 variable "workspace_policy" { default = null }
 variable "applications" { default = {} }
 variable "remote_state_consumer_names" { default = [] }
+variable "teams" {}
 
 module "workspaces" {
   source = "../../"
@@ -16,6 +17,7 @@ module "workspaces" {
   aws_region       = "eu-central-1"
   applications     = var.applications
   workspace_policy = var.workspace_policy
+  teams            = var.teams
 
   # N.B. There is no value for this in any of the tests, and it's only here to
   # ensure all possible fields are shown

--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,16 @@ resource "tfe_workspace" "this" {
   execution_mode = length(var.applications) == 0 ? try(var.workspace_execution_mode, "remote") : each.value["workspace_execution_mode"] != null ? each.value["workspace_execution_mode"] : try(var.workspace_execution_mode, "remote")
 }
 
+module "teams" {
+  for_each = local.application_workspaces
+
+  source = "./modules/team_access"
+
+  organization = var.organization
+  teams        = var.teams
+  workspace_id = tfe_workspace.this[each.key].id
+}
+
 module "variables" {
   source   = "./modules/tfe_variables"
   for_each = var.applications

--- a/modules/team_access/main.tf
+++ b/modules/team_access/main.tf
@@ -1,0 +1,22 @@
+data "tfe_team" "these" {
+  for_each = var.teams
+
+  name         = each.key
+  organization = var.organization
+}
+
+resource "tfe_team_access" "this" {
+  for_each = var.teams
+
+  team_id      = lookup(data.tfe_team.these, each.key).id
+  workspace_id = var.workspace_id
+
+  permissions {
+    runs              = each.value.runs
+    variables         = each.value.variables
+    state_versions    = each.value.state_versions
+    sentinel_mocks    = each.value.sentinel_mocks
+    workspace_locking = each.value.workspace_locking
+    run_tasks         = each.value.run_tasks
+  }
+}

--- a/modules/team_access/variables.tf
+++ b/modules/team_access/variables.tf
@@ -1,0 +1,19 @@
+variable "teams" {
+  description = "Teams to give access to the application workspaces created"
+
+  type = map(object({
+    runs              = optional(string, "apply"),
+    variables         = optional(string, "read"),
+    state_versions    = optional(string, "read"),
+    sentinel_mocks    = optional(string, "read"),
+    workspace_locking = optional(bool, false),
+    run_tasks         = optional(bool, true)
+  }))
+}
+
+variable "workspace_id" {
+  description = "Workspace to give access to"
+  type        = string
+}
+
+variable "organization" {}

--- a/tests/unit.tftest.hcl
+++ b/tests/unit.tftest.hcl
@@ -5,6 +5,17 @@ variables {
   project         = "constr"
   stage           = "dev"
   parent_zone     = "dev.constr.guidion.io"
+
+  teams = {
+    engineering = {
+      runs              = "apply"
+      variables         = "read"
+      state_versions    = "read"
+      sentinel_mocks    = "read"
+      workspace_locking = false
+      run_tasks         = true
+    }
+  }
 }
 
 # Application instance tests
@@ -22,6 +33,7 @@ run "application_workspaces" {
     project         = var.project
     stage           = var.stage
     parent_zone     = var.parent_zone
+    teams           = var.teams
 
     # A few applications to demonstrate different ways of setting permissions
     applications = {

--- a/variables.tf
+++ b/variables.tf
@@ -83,3 +83,18 @@ variable "remote_state_consumer_names" {
   description = "List of workspace names to share state of this workspace with"
   default     = []
 }
+
+variable "teams" {
+  description = "Teams to give access to the application workspaces created"
+
+  type = map(object({
+    runs              = optional(string, "apply"),
+    variables         = optional(string, "read"),
+    state_versions    = optional(string, "read"),
+    sentinel_mocks    = optional(string, "read"),
+    workspace_locking = optional(bool, false),
+    run_tasks         = optional(bool, true)
+  }))
+
+  default = {}
+}


### PR DESCRIPTION
New `var.teams` allows the specification of TFE teams add to the application workspaces the module creates. Custom permissions are possible, but the module has a default set of permissions too.