### PR TITLE
AWS Provider Upgrade

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.26.0"
+      version = "~> 5.92.0"
     }
 
     github = {
@@ -13,7 +13,7 @@ terraform {
     }
 
     tfe = {
-      source = "hashicorp/tfe"
+      source  = "hashicorp/tfe"
       version = "0.58.1"
     }
   }


### PR DESCRIPTION
BREAKING CHANGE: Allowing versions ~> 5.92.0 of AWS provider